### PR TITLE
Make more prominent data links

### DIFF
--- a/_data/about.yml
+++ b/_data/about.yml
@@ -6,6 +6,10 @@ summary:
     contributed to our 2022 survey to understand the size, diversity, origin an
     current levels of digitisation. The UK holds more than 137 million specimens
     recorded from 83 institutions and collected from across the world.
+  cta:
+    - text: Explore data
+      isPrimary: true
+      href: /specimen/search
 
 map:
   background: /assets/images/dissco_map.png

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -3,13 +3,15 @@
 - text: About
   href: /about
 - text: UK Specimens
-  href: /specimen/search
+  menu:
+    - text: Occurrences
+      href: /specimen/search
+    - text: Gallery
+      href: /specimen/search?view=GALLERY
+    - text: Map
+      href: /specimen/search?view=MAP
 - text: UK Institutions
   href: /institution/search
-- text: Gallery
-  href: /specimen/search?view=GALLERY
-- text: Map
-  href: /specimen/search?view=MAP
 - text: News
   href: /news
 - text: Resources


### PR DESCRIPTION
2 items here:

1. Add a link on the about page to the data:

![image](https://github.com/gbif/hp-uk-collections/assets/4718259/c4e714ea-3bcf-4ec5-b9a5-ee291557d551)

2. Change the navbar item for `UK Specimens` to a dropdown menu and collapse `Map` and `Gallery` into it. `Gallery` and `Map` being in the navbar made it cluttered and overstated their important (I think) so collapsing them cleans it up. Also, this makes the `UK Specimens` item a bit more prominent as there are fewer items in the navbar and it gets a down caret because of the added sub items:

![image](https://github.com/gbif/hp-uk-collections/assets/4718259/53da7750-ac4c-4275-9003-51cfb578d5b4)


Closes https://github.com/gbif/hp-uk-collections/issues/33