### PR TITLE
Add symlink at old path to blueprint

### DIFF
--- a/sites/default/files/2022-07/Harnessing the Power of Natural Science Collections.pdf
+++ b/sites/default/files/2022-07/Harnessing the Power of Natural Science Collections.pdf
@@ -1,0 +1,1 @@
+../../../../assets/Harnessing the Power of Natural Science Collections.pdf


### PR DESCRIPTION
On the old drupal dissco site, the blueprint was found at https://www.dissco-uk.org/sites/default/files/2022-07/Harnessing%20the%20Power%20of%20Natural%20Science%20Collections.pdf which is also used in a bitly link we shared. We can't update the link without paying sweet cash, so this is just a simple redirect to make sure that path is still available to users.