### PR TITLE
Add counts to home page with appropriate style and html changes

### DIFF
--- a/_data/home.yml
+++ b/_data/home.yml
@@ -52,6 +52,51 @@ main:
       document.getElementById("home-tab-institutions").classList.add("is-primary");
       document.getElementById("home-tab-specimens").classList.remove("is-primary");
     }
+
+    async function getGBIFCount(params) {
+      const response = await fetch(
+          `https://graphql.gbif.org/graphql?${params}`,
+          // use a 5 second timeout
+          {signal: AbortSignal.timeout(5000)}
+        );
+      const result = await response.json();
+      return result.data;
+    }
+
+    (async function getRecordCount() {
+      // the parameters for both institution count and specimen count requests have been
+      // nabbed from the search pages. GBIF's graphql is not stable and public so we're
+      // at the merci of GBIF and will need to keep these up to date.
+      const institutionParams = new URLSearchParams({
+        "queryId": "ed48400d668e18ea56353eb7dc2ad2057946c715",
+        "strict": true,
+        "variables": JSON.stringify({
+          "displayOnNHCPortal": true,
+          "country":"GB",
+          "active":true,
+          "limit":0,
+        }),
+      });
+      const specimenParams = new URLSearchParams({
+        "queryId": "23b0d9d449dd320f704fafca0de163cf18b745da",
+        "strict": true,
+        "variables": JSON.stringify({
+          "predicate": siteConfig.occurrence.rootPredicate,
+          "size": 0,
+        }),
+      });
+      try {
+        const specimenCount = (await getGBIFCount(specimenParams)).occurrenceSearch.documents.total;
+        const institutionCount = (await getGBIFCount(institutionParams)).institutionSearch.count;
+        document.getElementById("home-feature-subtitle-rcount").textContent = specimenCount.toLocaleString("en");
+        document.getElementById("home-feature-subtitle-icount").textContent = institutionCount;
+        document.getElementById("home-feature-subtitle-nocount").style.display = "none";
+        document.getElementById("home-feature-subtitle-count").style.display = "inline";
+      } catch (error) {
+        // swallow all errors, nom nom nom, but do log
+        console.log(`An error occurred while loading the counts: ${error}`);
+      }
+    })();
     </script>
 
     <div class="feature-img">
@@ -68,8 +113,10 @@ main:
 
     <div class="feature-content">
         <h1 class="home-feature-title">The Distributed System of Scientific Collections UK</h1>
-        <h2 class="home-feature-subtitle">Search UK natural science collections</h2>
-
+        <h2 class="home-feature-subtitle">
+          <span id="home-feature-subtitle-nocount">Search UK natural science collections</span>
+          <span id="home-feature-subtitle-count">Search <span id="home-feature-subtitle-rcount"></span> records from <span id="home-feature-subtitle-icount"></span> UK natural science collections</span>
+        </h2>
         <div class="home-search-wrapper">
             <div class="home-search">
                 <div class="home-tabs">

--- a/_sass/_main.scss
+++ b/_sass/_main.scss
@@ -181,9 +181,13 @@ Home page styling.
   @extend .home;
   @extend .hasWhiteText;
 
-  color: rgba(0, 0, 0, 0.333);
+  color: rgba(0, 0, 0, 0.45);
   height: auto;
   min-height: calc(100vh - var(--navbar-height));
+
+  .feature-content {
+    margin-bottom: calc(var(--navbar-height) / 2);
+  }
 
   .home-feature-title {
     color: white;
@@ -193,9 +197,17 @@ Home page styling.
   }
 
   .home-feature-subtitle {
-    color: white;
+    color: lightgray;
     font-size: 32px;
     font-weight: bold;
+  }
+
+  #home-feature-subtitle-count {
+    display: none;
+
+    span {
+      color: white;
+    }
   }
 
   .home-search-wrapper {


### PR DESCRIPTION
The counts are collected from the GBIF graphql API which is unstable and not public - we'll need to keep an eye on it to make sure things continue to work going forward. If the counts can't be collected then an alternative line is shown so that users don't get met with an error on the home page. Also worth noting, this change causes the home page to call the GBIF graphql every time it is loaded. They seem to have some decent caching in place so this isn't a problem from the user's perspective but we could cache it in a cookie or something if we wanted to be a bit kinder on their API. Realistically though, the number of people using the site isn't high enough for it to cause a problem and it doesn't impact initial page load times.