### PR TITLE
Add release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      body:
+        description: Additional release message
+        required: false
+        type: string
+
+jobs:
+  release:
+    name: Create a release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v7
+      - name: Get version
+        id: calc_version
+        uses: StephaneBour/actions-calver@master
+        with:
+          date_format: 'v%Y.%V'
+          version_regexp: '^v\d{4}\.\d{2}\.\d+$'
+          release: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Release
+        uses: softprops/action-gh-release@v3
+        with:
+          generate_release_notes: true
+          body: ${{ inputs.body }}
+          tag_name: ${{ steps.calc_version.outputs.release }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a workflow to make a release and tag from the master branch, just to make it a little bit easier and more standardised.